### PR TITLE
Adding environment variable for servername

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,6 +17,10 @@ if [ ! -z "$SSH_KEY" ]; then
  chmod 600 /root/.ssh/id_rsa
 fi
 
+if [ ! -z "$SERVER_NAME" ]; then
+ sed -i "s/server_name _/server_name $SERVER_NAME/g" /etc/nginx/sites-available/default.conf
+fi
+
 # Set custom webroot
 if [ ! -z "$WEBROOT" ]; then
  sed -i "s#root /var/www/html;#root ${WEBROOT};#g" /etc/nginx/sites-available/default.conf


### PR DESCRIPTION
Replaced the previously blank server name in the conf file with the servername environment variable to resolve a blank URL issue at logout